### PR TITLE
Write Github actions for publishing specs [SA-14289]

### DIFF
--- a/.github/actions/publish-design.yml
+++ b/.github/actions/publish-design.yml
@@ -34,7 +34,7 @@ jobs:
           rm -f .staging/docs/dist.yaml
           rm -f .staging/docs/builds.json
           git checkout gh-pages
-          mv .staging/* .
+          cp -r .staging/* .
           rm -rf .staging/
 
           # Commit and push

--- a/.github/actions/publish-design.yml
+++ b/.github/actions/publish-design.yml
@@ -38,6 +38,6 @@ jobs:
           rm -rf .staging/
 
           # Commit and push
-          git add docs/
+          git add .
           git commit -m "Build design for tag ${$GITHUB_REF}" .
           git push

--- a/.github/actions/publish-design.yml
+++ b/.github/actions/publish-design.yml
@@ -29,7 +29,7 @@ jobs:
 
           # Copy all files (excl. builds/, builds.json, dist.yaml) into gh-pages repo
           mkdir .staging/
-          cp -r . .staging/
+          cp -r ./* .staging/
           rm -rf .staging/docs/builds/
           rm -f .staging/docs/dist.yaml
           rm -f .staging/docs/builds.json

--- a/.github/actions/publish-design.yml
+++ b/.github/actions/publish-design.yml
@@ -23,8 +23,8 @@ jobs:
           # Copy docs (excl. builds/, builds.json, dist.yaml) into gh-pages repo
           cp -r docs* .staging
           rm -rf .staging/builds/
-          rm .staging/dist.yaml
-          rm .staging/builds.json
+          rm -f .staging/dist.yaml
+          rm -f .staging/builds.json
           git checkout gh-pages
           mv .staging/* docs/
           rm -rf .staging/

--- a/.github/actions/publish-design.yml
+++ b/.github/actions/publish-design.yml
@@ -1,0 +1,35 @@
+name: publish-spec
+
+# Publish of design versions happens on push to master.
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - docs/**
+jobs:
+  build:
+    if: github.repository == 'alaress/schoolbox-api-docs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push design to gh-pages branch
+        id: publish-design
+        run: |
+          # Commit on behalf of the github-actions bot
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Copy docs (excl. builds/, builds.json, dist.yaml) into gh-pages repo
+          cp -r docs* .staging
+          rm -rf .staging/builds/
+          rm .staging/dist.yaml
+          rm .staging/builds.json
+          git checkout gh-pages
+          mv .staging/* docs/
+          rm -rf .staging/
+
+          # Commit and push
+          git add docs/
+          git commit -m "Build design for tag ${$GITHUB_REF}" .
+          git push

--- a/.github/actions/publish-design.yml
+++ b/.github/actions/publish-design.yml
@@ -1,12 +1,19 @@
 name: publish-spec
 
 # Publish of design versions happens on push to master.
+# Needs to include:
+# * Design changes
+# * Anything required to actually build a spec, e.g. scripts, package files:
+#   not required immediately, but will be required when a spec is published
+# In practice, anything besides the actual published specs themselves
 on:
   push:
     branches:
       - master
-    paths:
-      - docs/**
+    paths-ignore:
+      - docs/builds/*
+      - docs/builds.json
+      - docs/dist.yaml
 jobs:
   build:
     if: github.repository == 'alaress/schoolbox-api-docs'
@@ -20,13 +27,14 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Copy docs (excl. builds/, builds.json, dist.yaml) into gh-pages repo
-          cp -r docs* .staging
-          rm -rf .staging/builds/
-          rm -f .staging/dist.yaml
-          rm -f .staging/builds.json
+          # Copy all files (excl. builds/, builds.json, dist.yaml) into gh-pages repo
+          mkdir .staging/
+          cp -r . .staging/
+          rm -rf .staging/docs/builds/
+          rm -f .staging/docs/dist.yaml
+          rm -f .staging/docs/builds.json
           git checkout gh-pages
-          mv .staging/* docs/
+          mv .staging/* .
           rm -rf .staging/
 
           # Commit and push

--- a/.github/actions/publish-spec-develop.yml
+++ b/.github/actions/publish-spec-develop.yml
@@ -33,7 +33,7 @@ jobs:
           cp -r docs/builds* .staging
           cp docs/builds.json .staging
           git checkout gh-pages
-          mv .staging/* docs/
+          cp -r .staging/* docs/
           rm -rf .staging/
 
           # Commit and push

--- a/.github/actions/publish-spec-develop.yml
+++ b/.github/actions/publish-spec-develop.yml
@@ -1,13 +1,14 @@
 name: publish-spec
 
-# Publish of spec versions happens on tag of either master or develop.
+# Publish of beta specs happens on tagging develop with an alpha or beta version
+# number.
 on:
   push:
     branches:
-      - master
       - develop
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.0-alpha[0-9]+"
+      - "[0-9]+.[0-9]+.0-beta[0-9]+"
     paths-ignore:
       - .github/workflows/**
 jobs:
@@ -18,19 +19,16 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.1.0
       - name: Push to gh-pages branch
-        id: publish-spec
+        id: publish-spec-develop
         run: |
           # Commit on behalf of the github-actions bot
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Build the docs
-          # if master: $selected is true, otherwise false
+          # Build the docs:
+          # do not set beta specs as the most recently selected
           npm ci
-          npm run build-new --build-version=$GITHUB_REF --selected
-          
-          # also if master: do the old build (for now)
-          npm run build
+          npm run build-new --build-version=$GITHUB_REF
 
           # Copy docs into gh-pages repo
           cp -r docs/builds* .staging

--- a/.github/actions/publish-spec-develop.yml
+++ b/.github/actions/publish-spec-develop.yml
@@ -29,6 +29,7 @@ jobs:
           npm run build-new --build-version=$GITHUB_REF
 
           # Copy docs into gh-pages repo
+          mkdir .staging/
           cp -r docs/builds* .staging
           cp docs/builds.json .staging
           git checkout gh-pages

--- a/.github/actions/publish-spec-develop.yml
+++ b/.github/actions/publish-spec-develop.yml
@@ -26,6 +26,7 @@ jobs:
           # Build the docs:
           # do not set beta specs as the most recently selected
           npm ci
+          npm run rebuild-builds-list
           npm run build-new --build-version=$GITHUB_REF
 
           # Copy docs into gh-pages repo

--- a/.github/actions/publish-spec-develop.yml
+++ b/.github/actions/publish-spec-develop.yml
@@ -9,8 +9,6 @@ on:
     tags:
       - "[0-9]+.[0-9]+.0-alpha[0-9]+"
       - "[0-9]+.[0-9]+.0-beta[0-9]+"
-    paths-ignore:
-      - .github/workflows/**
 jobs:
   build:
     if: github.repository == 'alaress/schoolbox-api-docs'
@@ -32,7 +30,6 @@ jobs:
 
           # Copy docs into gh-pages repo
           cp -r docs/builds* .staging
-          cp docs/dist.yaml .staging
           cp docs/builds.json .staging
           git checkout gh-pages
           mv .staging/* docs/

--- a/.github/actions/publish-spec-master.yml
+++ b/.github/actions/publish-spec-master.yml
@@ -8,8 +8,6 @@ on:
       - master
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
-    paths-ignore:
-      - .github/workflows/**
 jobs:
   build:
     if: github.repository == 'alaress/schoolbox-api-docs'

--- a/.github/actions/publish-spec-master.yml
+++ b/.github/actions/publish-spec-master.yml
@@ -30,6 +30,7 @@ jobs:
           npm run build
 
           # Copy docs into gh-pages repo
+          mkdir .staging/
           cp -r docs/builds* .staging
           cp docs/dist.yaml .staging
           cp docs/builds.json .staging

--- a/.github/actions/publish-spec-master.yml
+++ b/.github/actions/publish-spec-master.yml
@@ -1,0 +1,45 @@
+name: publish-spec
+
+# Publish of production specs happens on tagging master with a valid version
+# number.
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+    paths-ignore:
+      - .github/workflows/**
+jobs:
+  build:
+    if: github.repository == 'alaress/schoolbox-api-docs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.1.0
+      - name: Push to gh-pages branch
+        id: publish-spec-master
+        run: |
+          # Commit on behalf of the github-actions bot
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Build the docs
+          npm ci
+          npm run build-new --build-version=$GITHUB_REF --selected
+          
+          # also do the old build (for now)
+          npm run build
+
+          # Copy docs into gh-pages repo
+          cp -r docs/builds* .staging
+          cp docs/dist.yaml .staging
+          cp docs/builds.json .staging
+          git checkout gh-pages
+          mv .staging/* docs/
+          rm -rf .staging/
+
+          # Commit and push
+          git add docs/
+          git commit -m "Build spec for tag ${$GITHUB_REF}" .
+          git push

--- a/.github/actions/publish-spec-master.yml
+++ b/.github/actions/publish-spec-master.yml
@@ -35,7 +35,7 @@ jobs:
           cp docs/dist.yaml .staging
           cp docs/builds.json .staging
           git checkout gh-pages
-          mv .staging/* docs/
+          cp -r .staging/* docs/
           rm -rf .staging/
 
           # Commit and push

--- a/.github/actions/publish-spec-master.yml
+++ b/.github/actions/publish-spec-master.yml
@@ -24,6 +24,7 @@ jobs:
 
           # Build the docs
           npm ci
+          npm run rebuild-builds-list
           npm run build-new --build-version=$GITHUB_REF --selected
 
           # also do the old build (for now)

--- a/.github/actions/publish-spec-master.yml
+++ b/.github/actions/publish-spec-master.yml
@@ -25,7 +25,7 @@ jobs:
           # Build the docs
           npm ci
           npm run build-new --build-version=$GITHUB_REF --selected
-          
+
           # also do the old build (for now)
           npm run build
 

--- a/.github/actions/publish-spec.yml
+++ b/.github/actions/publish-spec.yml
@@ -1,0 +1,46 @@
+name: publish-spec
+
+# Publish of spec versions happens on tag of either master or develop.
+on:
+  push:
+    branches:
+      - master
+      - develop
+    tags:
+      - "*"
+    paths-ignore:
+      - .github/workflows/**
+jobs:
+  build:
+    if: github.repository == 'alaress/schoolbox-api-docs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.1.0
+      - name: Push to gh-pages branch
+        id: publish-spec
+        run: |
+          # Commit on behalf of the github-actions bot
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Build the docs
+          # if master: $selected is true, otherwise false
+          npm ci
+          npm run build-new --build-version=$GITHUB_REF --selected
+          
+          # also if master: do the old build (for now)
+          npm run build
+
+          # Copy docs into gh-pages repo
+          cp -r docs/builds* .staging
+          cp docs/dist.yaml .staging
+          cp docs/builds.json .staging
+          git checkout gh-pages
+          mv .staging/* docs/
+          rm -rf .staging/
+
+          # Commit and push
+          git add docs/
+          git commit -m "Build spec for tag ${$GITHUB_REF}" .
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 ./dist.yaml
 node_modules
 .idea
+.staging

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "redocly bundle -o docs/dist.yaml && ./scripts/applyVersion.js latest docs/dist.yaml",
     "build-new": "redocly bundle -o docs/builds/${npm_config_build_version}.yaml && ./scripts/addBuild.js ${npm_config_build_version} ${npm_config_selected} && ./scripts/applyVersion.js ${npm_config_build_version} docs/builds/${npm_config_build_version}.yaml",
+    "rebuild-builds-list": "./scripts/rebuildBuildsList.js",
     "test": "redocly lint"
   }
 }

--- a/scripts/addBuild.js
+++ b/scripts/addBuild.js
@@ -35,7 +35,7 @@ function main () {
     });
 
     // Sort by semver descending
-    buildsData.sort((a, b) => semver.rcompare(a.value, b.value));
+    buildsData.sort((a, b) => semver.rcompare(a.value, b.value, true));
 
     // Write
     fs.writeFileSync(buildsFile, JSON.stringify(buildsData, null, 2));

--- a/scripts/rebuildBuildsList.js
+++ b/scripts/rebuildBuildsList.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+const fs     = require("fs"),
+      path   = require('path'),
+      semver = require('semver');
+
+// Rebuild builds.json:
+// set the selected build as the most recent non-beta
+function main () {
+    const buildsFile           =  __dirname + `/../docs/builds.json`,
+          buildsFolder         =  __dirname + `/../docs/builds/`,
+          buildsFolderContents = fs.readdirSync(buildsFolder);
+    let buildsData = buildsFolderContents
+        .filter(file => path.extname(file) === '.yaml')
+        .map(function (file) {
+            let buildVersion = path.basename(file, '.yaml');
+            return {label: buildVersion, value: buildVersion};
+        });
+
+    // Sort by semver descending
+    buildsData.sort((a, b) => semver.rcompare(a.value, b.value, true));
+
+    // Set first non-beta build as the selected one
+    let hasSelectedBuild = false;
+    buildsData = buildsData.map(
+        function (v) {
+            if (!hasSelectedBuild) {
+                if (semver.prerelease(v.value, true) === null) {
+                    v.selected = true;
+                }
+            }
+            return v;
+        }
+    );
+
+    // Write
+    fs.writeFileSync(buildsFile, JSON.stringify(buildsData, null, 2));
+}
+main();

--- a/scripts/rebuildBuildsList.js
+++ b/scripts/rebuildBuildsList.js
@@ -23,6 +23,7 @@ function main () {
     let hasSelectedBuild = false;
     buildsData = buildsData.map(
         function (v) {
+            delete v.selected;
             if (!hasSelectedBuild) {
                 if (semver.prerelease(v.value, true) === null) {
                     v.selected = true;


### PR DESCRIPTION
This PR adds three Github actions for publishing changes to api.schoolbox.com.au:

# Added actions

## `publish-design.yml`

This action is intended for when changes are made to the documentation's frontend assets (e.g. images, CSS, HTML): it listens for changes to the `master` branch's `docs` folder, and copies said changes to the `gh-pages` branch.

Currently there is no NPM build step here, as the frontend assets don't require a build step: they are served directly as is.

## `publish-spec-master.yml`

This action is intended for when a new Schoolbox production release is created, and thus a new version of the API specification should be made available.

This action listens for new tags on the `master` branch: on a new tag being created, it
* builds the OpenAPI spec from the current `master` branch
* creates a new dropdown option for that tag in the published docs
  * this version will be selected by default
* pushes the newly created spec to the `gh-pages` branch

Currently it also pushes the built spec to `docs/dist.yaml`, so that the to-be-deprecated single-version docs will display the most recently published production version.

## `publish-spec-develop.yml`

This action is intended for when a new Schoolbox alpha or beta release is created, and thus a new version of the API specification should be made available (but be marked as beta).

This action listens for new tags on the `develop` branch: on a new tag being created, it
* builds the OpenAPI spec from the current `develop` branch
* creates a new dropdown option for that tag in the published docs
  * this version will _not_ be selected by default: the last `master` version will remain selected
* pushes the newly created spec to the `gh-pages` branch

# Still TODO
- [x] a method for removing no-longer-relevant versions: I see myself creating a lot of test versions in order to get this build process to work
  - could be as simple as manually removing specs for old versions from the `gh-pages` repo? If that's the case I'll need to add a script for rebuilding `docs/builds.json` from the content of `docs/builds`
- [ ] in the design: display available versions more intelligently
  - maybe something like this:
   ![image](https://user-images.githubusercontent.com/407053/194431801-1318ed91-bdd9-4735-ac06-c7fb7122a9b5.png)