### PR TITLE
Label Superuser endpoints with correct perms [SA-14636] (develop)

### DIFF
--- a/docs/dist.yaml
+++ b/docs/dist.yaml
@@ -1277,7 +1277,7 @@ paths:
                   description: the db identifier of the yearlevel
                   example: 6
                 name:
-                  type: integer
+                  type: string
                   description: the name of the year level. may not be unique
                   example: Year 6
             project:

--- a/docs/dist.yaml
+++ b/docs/dist.yaml
@@ -1187,7 +1187,7 @@ paths:
         - assessment
       summary: Get a list of assessments
       description: |
-        This endpoint will return all assessments and their results that match the filter provided.  We strongly recommend the use of due date filters, to ensure you only get relevant assessments from the current period.  For example a common request may be to get assessments of work type 'major' that are due in the current year.
+        This endpoint will return all assessments and their results that match the filter provided.  We strongly recommend the use of due date filters, to ensure you only get relevant assessments from the current period.  For example a common request may be to get assessments of work type 'major' that are due in the current year.   The endpoint is only available to superusers.
       responses:
         '200':
           $ref: '#/components/responses/assessment-list'
@@ -1297,7 +1297,7 @@ paths:
         - assessment
       summary: Get an assessment
       description: |
-        This will return all the information related to a specific assessment.  This will include the the assessment details and the results of all participants in that assessment.
+        This will return all the information related to a specific assessment.  This will include the the assessment details and the results of all participants in that assessment.   The endpoint is only available to superusers.
       responses:
         '200':
           $ref: '#/components/responses/assessment-item'
@@ -1311,7 +1311,7 @@ paths:
         - user
       summary: Create a user notification
       description: |
-        Send an instant notification to a selected user
+        Send an instant notification to a selected user.  The endpoint is only available to superusers.
       responses:
         '200':
           description: The notification was sent

--- a/openapi/paths/api@user@{id}@notify.yaml
+++ b/openapi/paths/api@user@{id}@notify.yaml
@@ -2,7 +2,7 @@ post:
   tags: [user]
   summary: Create a user notification
   description: |
-   Send an instant notification to a selected user
+   Send an instant notification to a selected user.  The endpoint is only available to superusers.
   responses:
     '200':
       description: The notification was sent

--- a/openapi/paths/assessment.yaml
+++ b/openapi/paths/assessment.yaml
@@ -3,7 +3,7 @@ get:
   tags: [assessment]
   summary: Get a list of assessments
   description: |
-    This endpoint will return all assessments and their results that match the filter provided.  We strongly recommend the use of due date filters, to ensure you only get relevant assessments from the current period.  For example a common request may be to get assessments of work type 'major' that are due in the current year.
+    This endpoint will return all assessments and their results that match the filter provided.  We strongly recommend the use of due date filters, to ensure you only get relevant assessments from the current period.  For example a common request may be to get assessments of work type 'major' that are due in the current year.   The endpoint is only available to superusers.
   responses:
     '200':
       $ref: ../components/responses/assessment-list.yaml

--- a/openapi/paths/assessment.yaml
+++ b/openapi/paths/assessment.yaml
@@ -94,7 +94,7 @@ parameters:
               description: the db identifier of the yearlevel
               example: 6
             name:
-              type: integer
+              type: string
               description: the name of the year level. may not be unique
               example: Year 6
         project:

--- a/openapi/paths/assessment@{id}.yaml
+++ b/openapi/paths/assessment@{id}.yaml
@@ -3,7 +3,7 @@ get:
   tags: [assessment]
   summary: Get an assessment
   description: |
-    This will return all the information related to a specific assessment.  This will include the the assessment details and the results of all participants in that assessment.
+    This will return all the information related to a specific assessment.  This will include the the assessment details and the results of all participants in that assessment.   The endpoint is only available to superusers.
   responses:
     '200':
       $ref: ../components/responses/assessment-item.yaml


### PR DESCRIPTION
User Notify and the Assessment API endpoints require the user to be a superuser.
This updates this in the docs
![image](https://user-images.githubusercontent.com/4447143/196845881-e94b3147-7537-48fc-a04d-4b5269cc38ea.png)

Bonus: Assessment API `filter[yearLevel][name]` should be `(string)` not int
![image](https://user-images.githubusercontent.com/4447143/196846314-00785ac6-0473-4738-ad0a-2b201d2db6ec.png)
