### PR TITLE
Move new docs to current, current to old [SA-14289]

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,25 +6,23 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    <link href="/styles.css" rel="stylesheet">
     <link rel="icon" type="image/png" href="./favicon.png">
-    <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
-    <script type="text/javascript">
-      if ('http:' === window.location.protocol && '?debug' !== window.location.search) {
-        window.location.protocol = 'https:';
-      }
-    </script>
+    <script type="module" src="https://unpkg.com/rapidoc@9.2.0/dist/rapidoc-min.js"></script>
+    <script type="text/javascript" src="/scripts.js"></script>
   </head>
   <body>
   <rapi-doc
-          spec-url="/dist.yaml"
+          id="rapidoc"
           schema-style="table"
           show-header="false"
           schema-description-expanded="true"
   >
-    <img
-            slot="nav-logo"
-            src="/logo.png"
-    />
+    <img slot="nav-logo" src="/logo.png" />
+    <div slot="nav-logo" class="version-selector">
+      <label for="version-selector">Version:</label>
+      <select id="version-selector"></select>
+    </div>
   </rapi-doc>
   </body>
 </html>

--- a/docs/old.html
+++ b/docs/old.html
@@ -6,23 +6,25 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-    <link href="/styles.css" rel="stylesheet">
     <link rel="icon" type="image/png" href="./favicon.png">
-    <script type="module" src="https://unpkg.com/rapidoc@9.2.0/dist/rapidoc-min.js"></script>
-    <script type="text/javascript" src="/scripts.js"></script>
+    <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+    <script type="text/javascript">
+      if ('http:' === window.location.protocol && '?debug' !== window.location.search) {
+        window.location.protocol = 'https:';
+      }
+    </script>
   </head>
   <body>
   <rapi-doc
-          id="rapidoc"
+          spec-url="/dist.yaml"
           schema-style="table"
           show-header="false"
           schema-description-expanded="true"
   >
-    <img slot="nav-logo" src="/logo.png" />
-    <div slot="nav-logo" class="version-selector">
-      <label for="version-selector">Version:</label>
-      <select id="version-selector"></select>
-    </div>
+    <img
+            slot="nav-logo"
+            src="/logo.png"
+    />
   </rapi-doc>
   </body>
 </html>


### PR DESCRIPTION
This makes the new API docs current, and the current docs old.
- https://api.schoolbox.com.au/new.html => https://api.schoolbox.com.au/
- https://api.schoolbox.com.au/ => https://api.schoolbox.com.au/old.html