### PR TITLE
updated perm note for userGet endpoint [SA-14774] (develop)

### DIFF
--- a/openapi/paths/user@{id}.yaml
+++ b/openapi/paths/user@{id}.yaml
@@ -3,7 +3,7 @@ get:
   tags: [user]
   summary: Get a user
   description: |
-    Returns all the information about a specific user. The result from this API can be passed into the update user endpoint. This endpoint may only be used by superusers.
+    Returns all the information about a specific user. The result from this API can be passed into the update user endpoint. This endpoint may only be used by the current user or superusers.
   responses:
     '200':
       $ref: ../components/responses/user-item.yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schoolbox-api",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "dependencies": {
     "@redocly/cli": "^1.0.0-beta.109",
     "@redocly/openapi-core": "^1.0.0-beta.109",


### PR DESCRIPTION
### Updating the `GET /api/user/{id}` endpoint

This change will allow the requesting user to view information about themselves in addition to the existing functionality of superusers current ability to view all users