### PR TITLE
Remove references to deleted module 'boarder leave' [SA-14766] develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,6 @@
 
 ### Usage
 
-#### Variants
-
-There are currently two variants of the API reference:
-
-##### Single version
-
-The single-version variant supports only the most recently built version of the 
-API reference.
-
-This version is the current default, but will eventually be superseded by the
-multiple version variant described below.
-
-##### Multiple version
-
-The multi-version variant supports the most recently built version of the API
-reference, and also allows selection of:
-* previous versions
-* pre-release versions
-
 #### Previewing API docs locally
 
 Start the reference docs preview server in the `docs` folder:
@@ -36,8 +17,11 @@ cd docs;
 python3 -m http.server;
 ```
 
-Then, visit http://127.0.0.1:8000/?debug (for the old single-version docs) or
-http://127.0.0.1:8000/new.html?debug (for the new multi-version docs).
+Then, visit http://127.0.0.1:8000/?debug.
+
+Note the version selector at the top-left of the page, under the Schoolbox logo.  This allows selection of:
+* previous versions
+* pre-release versions
 
 In order to view changes to the docs, run one of the "Building API docs locally"
 steps provided below:

--- a/openapi/components/schemas/user-fields.yaml
+++ b/openapi/components/schemas/user-fields.yaml
@@ -73,10 +73,6 @@ properties:
       The user's job or position title within the school which owns the
       Schoolbox instance.
 
-  isBoarder:
-    type: boolean
-    description: Is this user a boarder?
-
   flags:
     type: object
     description: |


### PR DESCRIPTION
Note that the change to README.md is unrelated to the removal of the 'boarder leave' module.  I just noticed that that text was out of date, and so fixed it.

Question for the reviewer:
 * There is a file named residentialHouse.yaml in openapi/components/schemas that I think might be related to the boarder leave system.  Should this file be removed?