### PR TITLE
Update curriculum node usage API docs [SA-15037]

### DIFF
--- a/openapi/components/responses/curriculumNodeUsage-list.yaml
+++ b/openapi/components/responses/curriculumNodeUsage-list.yaml
@@ -1,0 +1,5 @@
+description: A list of curriculum node usages
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/curriculumNodeUsage-list.yaml

--- a/openapi/components/responses/curriculumNodeUsage-list.yaml
+++ b/openapi/components/responses/curriculumNodeUsage-list.yaml
@@ -1,4 +1,4 @@
-description: A list of curriculum node usages
+description: Provides all locations where this curriculum has been mapped
 content:
   application/json:
     schema:

--- a/openapi/components/schemas/curriculumNodeUsage-courseItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-courseItem.yaml
@@ -11,6 +11,20 @@ properties:
     properties:
       id:
         $ref: id.yaml
-      name:
+      title:
         type: string
         description: The name of the course.
+      subjectCode:
+        type: string
+        description: The course's subject code.
+      _links:
+        type: object
+        properties:
+          modify:
+            type: string
+            format: uri-reference
+            description: A link to the modify page for this course.
+          folder:
+            type: string
+            format: uri-reference
+            description: A link to the homepage for this course.

--- a/openapi/components/schemas/curriculumNodeUsage-courseItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-courseItem.yaml
@@ -1,0 +1,13 @@
+title: A course usage
+description: A course usage
+readOnly: true
+type: object
+properties:
+  id:
+    $ref: id.yaml
+  name:
+    type: string
+    description: The name of the course.
+  type:
+    type: string
+    enum: [course]

--- a/openapi/components/schemas/curriculumNodeUsage-courseItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-courseItem.yaml
@@ -3,11 +3,14 @@ description: A course usage
 readOnly: true
 type: object
 properties:
-  id:
-    $ref: id.yaml
-  name:
-    type: string
-    description: The name of the course.
-  type:
+  discriminator:
     type: string
     enum: [course]
+  object:
+    type: object
+    properties:
+      id:
+        $ref: id.yaml
+      name:
+        type: string
+        description: The name of the course.

--- a/openapi/components/schemas/curriculumNodeUsage-courseItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-courseItem.yaml
@@ -17,14 +17,13 @@ properties:
       subjectCode:
         type: string
         description: The course's subject code.
+      folder:
+        $ref: ./curriculumNodeUsage-folderItem.yaml
       _links:
         type: object
         properties:
-          modify:
+          view:
             type: string
             format: uri-reference
-            description: A link to the modify page for this course.
-          folder:
-            type: string
-            format: uri-reference
-            description: A link to the homepage for this course.
+            description: |
+              A link to view this course: contains a modify form.

--- a/openapi/components/schemas/curriculumNodeUsage-folderItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-folderItem.yaml
@@ -3,11 +3,14 @@ description: A folder usage
 readOnly: true
 type: object
 properties:
-  id:
-    $ref: id.yaml
-  name:
-    type: string
-    description: The name of the folder.
-  type:
+  discriminator:
     type: string
     enum: [folder]
+  object:
+    type: object
+    properties:
+      id:
+        $ref: id.yaml
+      name:
+        type: string
+        description: The name of the folder.

--- a/openapi/components/schemas/curriculumNodeUsage-folderItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-folderItem.yaml
@@ -1,0 +1,13 @@
+title: A folder usage
+description: A folder usage
+readOnly: true
+type: object
+properties:
+  id:
+    $ref: id.yaml
+  name:
+    type: string
+    description: The name of the folder.
+  type:
+    type: string
+    enum: [folder]

--- a/openapi/components/schemas/curriculumNodeUsage-folderItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-folderItem.yaml
@@ -14,3 +14,17 @@ properties:
       name:
         type: string
         description: The name of the folder.
+      title:
+        type: string
+        description: The name of the folder, including any class codes.
+      code:
+        type: array
+        items: string
+        description: A list of class codes (if any) associated with this folder.
+      _links:
+        type: object
+        properties:
+          view:
+            type: string
+            format: uri-reference
+            description: A link to the homepage for this folder.

--- a/openapi/components/schemas/curriculumNodeUsage-list.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-list.yaml
@@ -5,7 +5,7 @@ properties:
     items:
       type: object
       discriminator:
-        propertyName: type
+        propertyName: discriminator
         mapping:
           folder: ./curriculumNodeUsage-folderItem.yaml
           course: ./curriculumNodeUsage-courseItem.yaml
@@ -14,26 +14,5 @@ properties:
         - $ref: ./curriculumNodeUsage-folderItem.yaml
         - $ref: ./curriculumNodeUsage-courseItem.yaml
         - $ref: ./curriculumNodeUsage-unitItem.yaml
-#      properties:
-#        discriminator:
-#          type: string
-#          enum:
-#            - folder
-#            - course
-#            - unit
-#        object:
-#          type: object
-#          properties:
-#            id:
-#              $ref: id.yaml
-#            name:
-#              type: string
-#              description: The name of the node.
-#        date:
-#          type: string
-#          format: date-time
-#          description: |
-#            The date as a RFC3339 string.
-#          example: 2022-08-30T10:09:09+10:00
   metadata:
     $ref: ./listMetadata.yaml

--- a/openapi/components/schemas/curriculumNodeUsage-list.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-list.yaml
@@ -1,0 +1,32 @@
+title: Curriculum node usage
+type: object
+properties:
+  data:
+    type: array
+    items:
+      type: object
+#      discriminator:
+#        propertyName: discriminator
+      properties:
+        discriminator:
+          type: string
+          enum:
+            - folder
+            - course
+            - unit
+        object:
+          type: object
+          properties:
+            id:
+              $ref: id.yaml
+            name:
+              type: string
+              description: The name of the node.
+        date:
+          type: string
+          format: date-time
+          description: |
+            The date as a RFC3339 string.
+          example: 2022-08-30T10:09:09+10:00
+  metadata:
+    $ref: ./listMetadata.yaml

--- a/openapi/components/schemas/curriculumNodeUsage-list.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-list.yaml
@@ -1,32 +1,39 @@
-title: Curriculum node usage
 type: object
 properties:
   data:
     type: array
     items:
       type: object
-#      discriminator:
-#        propertyName: discriminator
-      properties:
-        discriminator:
-          type: string
-          enum:
-            - folder
-            - course
-            - unit
-        object:
-          type: object
-          properties:
-            id:
-              $ref: id.yaml
-            name:
-              type: string
-              description: The name of the node.
-        date:
-          type: string
-          format: date-time
-          description: |
-            The date as a RFC3339 string.
-          example: 2022-08-30T10:09:09+10:00
+      discriminator:
+        propertyName: type
+        mapping:
+          folder: ./curriculumNodeUsage-folderItem.yaml
+          course: ./curriculumNodeUsage-courseItem.yaml
+          unit: ./curriculumNodeUsage-unitItem.yaml
+      anyOf:
+        - $ref: ./curriculumNodeUsage-folderItem.yaml
+        - $ref: ./curriculumNodeUsage-courseItem.yaml
+        - $ref: ./curriculumNodeUsage-unitItem.yaml
+#      properties:
+#        discriminator:
+#          type: string
+#          enum:
+#            - folder
+#            - course
+#            - unit
+#        object:
+#          type: object
+#          properties:
+#            id:
+#              $ref: id.yaml
+#            name:
+#              type: string
+#              description: The name of the node.
+#        date:
+#          type: string
+#          format: date-time
+#          description: |
+#            The date as a RFC3339 string.
+#          example: 2022-08-30T10:09:09+10:00
   metadata:
     $ref: ./listMetadata.yaml

--- a/openapi/components/schemas/curriculumNodeUsage-unitItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-unitItem.yaml
@@ -3,11 +3,14 @@ description: A unit usage
 readOnly: true
 type: object
 properties:
-  id:
-    $ref: id.yaml
-  name:
-    type: string
-    description: The name of the unit.
-  type:
+  discriminator:
     type: string
     enum: [unit]
+  object:
+    type: object
+    properties:
+      id:
+        $ref: id.yaml
+      name:
+        type: string
+        description: The name of the unit.

--- a/openapi/components/schemas/curriculumNodeUsage-unitItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-unitItem.yaml
@@ -11,6 +11,17 @@ properties:
     properties:
       id:
         $ref: id.yaml
-      name:
+      title:
         type: string
         description: The name of the unit.
+      _links:
+        type: object
+        properties:
+          modify:
+            type: string
+            format: uri-reference
+            description: A link to the modify page for this unit's course.
+          folder:
+            type: string
+            format: uri-reference
+            description: A link to the homepage for this unit.

--- a/openapi/components/schemas/curriculumNodeUsage-unitItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-unitItem.yaml
@@ -14,14 +14,15 @@ properties:
       title:
         type: string
         description: The name of the unit.
+      folder:
+        $ref: ./curriculumNodeUsage-folderItem.yaml
+      course:
+        $ref: ./curriculumNodeUsage-courseItem.yaml
       _links:
         type: object
         properties:
-          modify:
+          view:
             type: string
             format: uri-reference
-            description: A link to the modify page for this unit's course.
-          folder:
-            type: string
-            format: uri-reference
-            description: A link to the homepage for this unit.
+            description: |
+              A link to view this unit's course: contains a modify form.

--- a/openapi/components/schemas/curriculumNodeUsage-unitItem.yaml
+++ b/openapi/components/schemas/curriculumNodeUsage-unitItem.yaml
@@ -1,0 +1,13 @@
+title: A unit usage
+description: A unit usage
+readOnly: true
+type: object
+properties:
+  id:
+    $ref: id.yaml
+  name:
+    type: string
+    description: The name of the unit.
+  type:
+    type: string
+    enum: [unit]

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -233,6 +233,9 @@ paths:
   /pastoral/record/insert:
     $ref: 'paths/pastoral@record@insert.yaml'
 
+  /api/curriculum/usage/{id}:
+    $ref: 'paths/api@curriculum@usage@{id}.yaml'
+
 security:
   # Authorization is handled by Schoolbox itself once a user is authenticated:
   # therefore, no scopes are defined for any security scheme.

--- a/openapi/paths/api@curriculum@usage@{id}.yaml
+++ b/openapi/paths/api@curriculum@usage@{id}.yaml
@@ -1,0 +1,15 @@
+get:
+  tags: [curriculum]
+  summary:
+  description: |
+   Get curriculum node usage
+  responses:
+    '200':
+      $ref: ../components/responses/curriculumNodeUsage-list.yaml
+    default:
+      $ref: ../components/responses/problem.yaml
+
+parameters:
+  - $ref: ../components/parameters/id.yaml
+  - $ref: ../components/parameters/cursor.yaml
+  - $ref: ../components/parameters/limit.yaml


### PR DESCRIPTION
Built upon #95, and built to match https://github.com/alaress/schoolbox/pull/27427

The usage docs now contain the course's folder, and the unit's course (which itself now contains a folder).

I would've updated the curriculum API docs, but docs for the curriculum API don't exist!