### PR TITLE
Update API docs with more accurate evidence feed schemas

### DIFF
--- a/openapi/components/responses/evidence-list.yaml
+++ b/openapi/components/responses/evidence-list.yaml
@@ -2,13 +2,24 @@ description: A list of Learning Moments
 content:
   application/json:
     schema:
-      discriminator:
-        propertyName: discriminator
-        mapping:
-          evidence: ../schemas/evidenceList.yaml
-          badgeAward: ../schemas/badgeAwardList.yaml
-          dueWorkFeedback: ../schemas/dueWorkFeedbackList.yaml
-      oneOf:
-        - $ref: ../schemas/evidenceList.yaml
-        - $ref: ../schemas/badgeAwardList.yaml
-        - $ref: ../schemas/dueWorkFeedbackList.yaml
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            oneOf:
+              - $ref: ../schemas/evidenceList.yaml
+              - $ref: ../schemas/badgeAwardList.yaml
+              - $ref: ../schemas/dueWorkFeedbackList.yaml
+            required:
+              - discriminator
+          discriminator:
+            propertyName: discriminator
+            mapping:
+              evidence: ../schemas/evidenceList.yaml
+              badgeAward: ../schemas/badgeAwardList.yaml
+              dueWorkFeedback: ../schemas/dueWorkFeedbackList.yaml
+          minItems: 0
+        metadata:
+          $ref: ../schemas/listMetadata.yaml

--- a/openapi/components/schemas/badgeAwardList.yaml
+++ b/openapi/components/schemas/badgeAwardList.yaml
@@ -1,33 +1,14 @@
 title: Badge
 type: object
 properties:
-  data:
-    type: array
-    items:
-      type: object
-      properties:
-        discriminator:
-          type: string
-          example: badgeAward
-        object:
-          $ref: ./badgeAwardItem.yaml
-        date:
-          type: string
-          format: date-time
-          description: |
-            The date as a RFC3339 string.
-          example: 2022-08-30T10:09:09+10:00
-  metadata:
-    type: object
-    properties:
-      count:
-        type: integer
-        example: 18
-      cursor:
-        type: object
-        properties:
-          current:
-            type: string
-            nullable: true
-          next:
-            type: string
+  discriminator:
+    type: string
+    example: badgeAward
+  object:
+    $ref: ./badgeAwardItem.yaml
+  date:
+    type: string
+    format: date-time
+    description: |
+      The date as a RFC3339 string.
+    example: 2022-08-30T10:09:09+10:00

--- a/openapi/components/schemas/dueWorkFeedbackList.yaml
+++ b/openapi/components/schemas/dueWorkFeedbackList.yaml
@@ -1,33 +1,14 @@
 title: Due Work Feedback
 type: object
 properties:
-  data:
-    type: array
-    items:
-      type: object
-      properties:
-        discriminator:
-          type: string
-          example: dueWorkFeedback
-        object:
-          $ref: ./dueWorkFeedbackItem.yaml
-        date:
-          type: string
-          format: date-time
-          description: |
-            The date as a RFC3339 string.
-          example: 2022-08-30T10:09:09+10:00
-  metadata:
-    type: object
-    properties:
-      count:
-        type: integer
-        example: 18
-      cursor:
-        type: object
-        properties:
-          current:
-            type: string
-            nullable: true
-          next:
-            type: string
+  discriminator:
+    type: string
+    example: dueWorkFeedback
+  object:
+    $ref: ./dueWorkFeedbackItem.yaml
+  date:
+    type: string
+    format: date-time
+    description: |
+      The date as a RFC3339 string.
+    example: 2022-08-30T10:09:09+10:00

--- a/openapi/components/schemas/evidenceList.yaml
+++ b/openapi/components/schemas/evidenceList.yaml
@@ -1,33 +1,14 @@
 title: Evidence
 type: object
 properties:
-  data:
-    type: array
-    items:
-      type: object
-      properties:
-        discriminator:
-          type: string
-          example: evidence
-        object:
-          $ref: ./evidenceItem.yaml
-        date:
-          type: string
-          format: date-time
-          description: |
-            The date as a RFC3339 string.
-          example: 2022-08-30T10:09:09+10:00
-  metadata:
-    type: object
-    properties:
-      count:
-        type: integer
-        example: 18
-      cursor:
-        type: object
-        properties:
-          current:
-            type: string
-            nullable: true
-          next:
-            type: string
+  discriminator:
+    type: string
+    example: evidence
+  object:
+    $ref: ./evidenceItem.yaml
+  date:
+    type: string
+    format: date-time
+    description: |
+      The date as a RFC3339 string.
+    example: 2022-08-30T10:09:09+10:00


### PR DESCRIPTION
This pull fixes a few issues I've encountered with the evidence feed API docs. These include:
- Redundant `metadata` properties for pagination (also in the wrong place)
- Response depicted as a single object (one of dueWork, evidence, etc) missing the parent `data` and `metadata` properties.

Also switched to `listMetadata.yaml` to avoid duplication. Understand that this pull may not be accepted in its current form but will hopefully get the idea across better than an issue.

Current docs:
<img width="848" alt="image" src="https://user-images.githubusercontent.com/37988348/234832628-c192b67d-0e5f-4f97-aacd-a68b895e26b6.png">

Updated docs:
<img width="824" alt="image" src="https://user-images.githubusercontent.com/37988348/234833248-ce5d13e0-951b-4368-aa0d-76670da7ff3e.png">

Actual response:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/37988348/234834634-872f8a05-f750-47ed-b7b0-a45f060a168b.png">

