### PR TITLE
Update API docs to match actual responses [SA-15583] develop

### DIFF
--- a/openapi/components/schemas/assessment-item.yaml
+++ b/openapi/components/schemas/assessment-item.yaml
@@ -16,6 +16,7 @@ properties:
       - task
       - project
       - LTI
+      - lessonPlan
     example: task
   folder:
     description: |
@@ -50,10 +51,15 @@ properties:
               description: The name of the year level.
   commonAssessment:
     type: boolean
+    nullable: true
+    description: |
+      Only applicable for assessmentType 'dueWork' (so value will be null for other assessmentTypes).
   workType:
     type: object
+    nullable: true
     description: |
-      System configurable in your Admin Lists Work Types area
+      System configurable in your Admin Lists Work Types area.
+      Not applicable to assessmentType 'lessonPlan' (so value will be null in that case).
     properties:
       id:
         type: integer
@@ -65,11 +71,13 @@ properties:
         example: Formative Assessment
   weight:
     type: integer
+    nullable: true
     example: 30
     description: |
       The value of how much this assessment's outcome contributes to the final overall grade -
       a value of 0 indicates this assessment has no impact on the overall grade.
       Generally, this is a number between 0 and 100.
+      Not applicable to assessmentTypes 'lessonPlan' and 'task' (so value will be null in those cases).
   dueDate:
     type: string
     format: date-time
@@ -87,5 +95,7 @@ properties:
         example: 255
   participants:
     type: array
+    nullable: true
     items:
       $ref: ./assessment-participation-item.yaml
+    description: Not applicable to assessmentType 'lessonPlan' (so value will be null in that case).


### PR DESCRIPTION
This PR replaces https://github.com/alaress/schoolbox-api-docs/pull/118.

## Updated docs:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/a23ab197-fe1c-47f5-a52d-bc8ca1bd5965)

## Actual responses:

dueWork:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/d1837ea2-6147-4966-8f84-737c38680743)

lessonPlan:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/73ec9975-75af-44a0-aeb3-44086ec0ae23)

project:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/5ea53649-d69d-40e5-8210-7f1b4d47d695)

quiz:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/d77940be-20a2-45cc-aea5-b7734cca5c86)

task:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/e278caf9-faca-4f79-8b23-ef7f327dae68)
