### PR TITLE
Add CSP meta tag [SA-16123]

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,16 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
     <link href="/styles.css" rel="stylesheet">
     <link rel="icon" type="image/png" href="./favicon.png">
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        img-src 'self' data:;
+        script-src 'self' unpkg.com;
+        style-src 'self' 'unsafe-inline';
+        font-src 'self' fonts.googleapis.com fonts.gstatic.com
+      "
+    >
     <script type="module" src="https://unpkg.com/rapidoc@9.3.4/dist/rapidoc-min.js"></script>
     <script type="text/javascript" src="/scripts.js"></script>
   </head>


### PR DESCRIPTION
Schoolbox's API docs continue to function as before with this change in place.

Making API requests via these docs doesn't function, but it didn't even without a CSP header: there's a CORS policy on Schoolbox instances which prevents these requests currently?