### PR TITLE
Fix nullable definitions [SA-16016]

### DIFF
--- a/openapi/components/schemas/calendarAttendance.yaml
+++ b/openapi/components/schemas/calendarAttendance.yaml
@@ -25,7 +25,8 @@ properties:
       status:
         allOf:
         - $ref: ./calendarAttendanceStatus.yaml
-        - nullable: true
+        - type: object
+          nullable: true
       canModify:
         description: |
           Can the authenticated user modify the event?

--- a/openapi/components/schemas/search/resultTypes/common.yaml
+++ b/openapi/components/schemas/search/resultTypes/common.yaml
@@ -59,10 +59,11 @@ properties:
     nullable: true
   creator:
     allOf:
-      - description: |
+      - type: object
+        description: |
           An optional creator of this search result.
+        nullable: true
       - $ref: ../../userAuthor.yaml
-    nullable: true
   context:
     type: array
     description: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "schoolbox-api",
       "version": "1.2.10",
       "dependencies": {
-        "@redocly/cli": "^1.0.0-beta.109",
+        "@redocly/cli": "^1.0.2",
         "@redocly/openapi-core": "^1.0.0-beta.109",
         "semver": "^7.3.7"
       }
@@ -525,11 +525,11 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "1.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.0.0-rc.1.tgz",
-      "integrity": "sha512-5pIgP5BNizRx5O0cg8ZF0vbhG703zzLg3Ai8tZOjSnaq+ir9FfM4Vq/JSN9afOVXvICle970GMROiHjqD75Z6w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.0.2.tgz",
+      "integrity": "sha512-IWuo5V2ZKSdvQMgNx05PHBlv1YvqJH3/nX52qslooEtqsvOaCUnZIm/aCd1zw2EW5Ub2+VLb51LqMt6mDF/9vQ==",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-rc.1",
+        "@redocly/openapi-core": "1.0.2",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-rc.1.tgz",
-      "integrity": "sha512-u/QvlXrYblDQXRWWeuoIjjVeliUIcanWSMeWQ8tZtyczcPbrvOlyEZnSAIRuadJcGs8agn2qnEXoEhUIJxtXWw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.2.tgz",
+      "integrity": "sha512-53dzhmG2bsi/8rcAAgBKk9ZLMR035VHgN7oSM3+BM4UAIoNBg6lMC/ChHSf9zO+GrX5qtuWVPqHhjjMti3SAlQ==",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
         "@types/node": "^14.11.8",
@@ -3298,11 +3298,11 @@
       }
     },
     "@redocly/cli": {
-      "version": "1.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.0.0-rc.1.tgz",
-      "integrity": "sha512-5pIgP5BNizRx5O0cg8ZF0vbhG703zzLg3Ai8tZOjSnaq+ir9FfM4Vq/JSN9afOVXvICle970GMROiHjqD75Z6w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.0.2.tgz",
+      "integrity": "sha512-IWuo5V2ZKSdvQMgNx05PHBlv1YvqJH3/nX52qslooEtqsvOaCUnZIm/aCd1zw2EW5Ub2+VLb51LqMt6mDF/9vQ==",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-rc.1",
+        "@redocly/openapi-core": "1.0.2",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
@@ -3321,9 +3321,9 @@
       }
     },
     "@redocly/openapi-core": {
-      "version": "1.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-rc.1.tgz",
-      "integrity": "sha512-u/QvlXrYblDQXRWWeuoIjjVeliUIcanWSMeWQ8tZtyczcPbrvOlyEZnSAIRuadJcGs8agn2qnEXoEhUIJxtXWw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.2.tgz",
+      "integrity": "sha512-53dzhmG2bsi/8rcAAgBKk9ZLMR035VHgN7oSM3+BM4UAIoNBg6lMC/ChHSf9zO+GrX5qtuWVPqHhjjMti3SAlQ==",
       "requires": {
         "@redocly/ajv": "^8.11.0",
         "@types/node": "^14.11.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "schoolbox-api",
   "version": "1.2.10",
   "dependencies": {
-    "@redocly/cli": "^1.0.0-beta.109",
+    "@redocly/cli": "^1.0.2",
     "@redocly/openapi-core": "^1.0.0-beta.109",
     "semver": "^7.3.7"
   },


### PR DESCRIPTION
Turns out that more recent redocly versions complain about `nullable` if it's not directly within a `type: object` definition, even if it's part of an `allOf` whose other part is also an object. Simple fix though.

I've also updated redocly to a 1.0 production version.