### PR TITLE
Update search filter date format to YYYY-MM-DD [SA-16563-3] develop

### DIFF
--- a/openapi/components/parameters/search/filter.yaml
+++ b/openapi/components/parameters/search/filter.yaml
@@ -56,14 +56,14 @@ schema:
           type: string
           format: date-time
           description: |
-            An RFC3339 time string including timezone.
-          example: '2023-01-01T00:00:00Z'
+            A date in YYYY-MM-DD format.
+          example: '2023-01-01'
         to:
           type: string
           format: date-time
           description: |
-            An RFC3339 time string including timezone.
-          example: '2023-12-31T23:59:59Z'
+            A date in YYYY-MM-DD format.
+          example: '2023-12-31'
 
     creator:
       type: object


### PR DESCRIPTION
This is to update the API docs following the changes made in https://github.com/alaress/schoolbox/pull/29231.

Note below the filter 'from' and 'to' dates are now specified as YYYY-MM-DD.
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/a10c8bbe-41c2-431a-94c6-79a3729f999f)