### PR TITLE
Update docs for impersonableUsers to match actual output [SA-17004] develop

### DIFF
--- a/openapi/components/schemas/user-readableFields.yaml
+++ b/openapi/components/schemas/user-readableFields.yaml
@@ -85,14 +85,15 @@ properties:
       - id: 69
         externalId: 69
         title: null
-        firstName: "Eden"
-        preferredName: "Reed"
-        givenName: "Eden"
-        lastName: "Reed"
-        fullName: "Eden Reed"
+        firstName: Eden
+        preferredName: Reed
+        givenName: Eden
+        lastName: Reed
+        fullName: Eden Reed
         role:
           id: 5
           name: Junior Student
+          type: student
         yearLevel:
           id: 4
           name: "3"

--- a/openapi/components/schemas/user-readableFields.yaml
+++ b/openapi/components/schemas/user-readableFields.yaml
@@ -82,15 +82,21 @@ properties:
       $ref: ./userShort.yaml
     nullable: false
     example:
-      - id: 6
-        fullName: Eden Reed
-        yearLevel:
-          id: 3
-          name: 3
+      - id: 69
+        externalId: 69
+        title: null
+        firstName: "Eden"
+        preferredName: "Reed"
+        givenName: "Eden"
+        lastName: "Reed"
+        fullName: "Eden Reed"
         role:
           id: 5
-          name: Primary Student
-  
+          name: Junior Student
+        yearLevel:
+          id: 4
+          name: "3"
+
   email:
     type: string
     format: email

--- a/openapi/components/schemas/userShort.yaml
+++ b/openapi/components/schemas/userShort.yaml
@@ -48,3 +48,9 @@ properties:
     nullable: false
     description: The user's formatted full name.
     example: Ms Rebecca White
+
+  role:
+    $ref: ./role.yaml
+
+  yearLevel:
+    $ref: ./yearLevel.yaml


### PR DESCRIPTION
## Overview

This PR updates the API docs for impersonable users to match the actual ouptut as of https://github.com/alaress/schoolbox/pull/29686.

## Before

Schema:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/f284e580-6490-46d9-8bf8-765c5da8489e)

Example:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/0aa36bb8-39d6-43f1-8cb5-8a5443fdaca1)


## After

Schema:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/e555b3aa-f80f-4a11-b80d-de987219fc0f)

Example:
![image](https://github.com/alaress/schoolbox-api-docs/assets/1623454/3c1c4aff-68e6-43ca-aa4a-7310707c516b)