### PR TITLE
Remove redundant description for 'limit' param [SA-19198] master

### DIFF
--- a/openapi/components/parameters/limit.yaml
+++ b/openapi/components/parameters/limit.yaml
@@ -1,19 +1,14 @@
 name:        limit
 in:          query
 description: |
-  Limit the returned results to this count.
+  An option to limit the returned results.
 
   Each endpoint whose data accepts a limit will limit
   their results to that number.
+
+  Note a maximum limit may also apply, depending on the
+  specific type of request.
 schema:
   title: Limit
-  description: |
-    An option to limit the returned results.
-
-    Each endpoint whose data accepts a limit will limit
-    their results to that number.
-
-    Note a maximum limit may also apply, depending on the
-    specific type of request.
   type: integer
 


### PR DESCRIPTION
This PR removes a redundant description in limit.yaml.  That file is now structured like id.yaml, and jwt.yaml, and key.yaml - as it should be.

Before:
![image](https://github.com/user-attachments/assets/6a8eeaf5-6fcd-4edf-9e4c-a4ccf4b65285)

After:
![image](https://github.com/user-attachments/assets/171d35b2-b206-4476-a473-cecf437685d9)

