### PR TITLE
Remove redundant description for 'limit' param [SA-19198] develop

### DIFF
--- a/openapi/components/parameters/limit.yaml
+++ b/openapi/components/parameters/limit.yaml
@@ -1,19 +1,14 @@
 name:        limit
 in:          query
 description: |
-  Limit the returned results to this count.
+  An option to limit the returned results.
 
   Each endpoint whose data accepts a limit will limit
   their results to that number.
+
+  Note a maximum limit may also apply, depending on the
+  specific type of request.
 schema:
   title: Limit
-  description: |
-    An option to limit the returned results.
-
-    Each endpoint whose data accepts a limit will limit
-    their results to that number.
-
-    Note a maximum limit may also apply, depending on the
-    specific type of request.
   type: integer
 


### PR DESCRIPTION
See comments in corresponding PR for master (https://github.com/alaress/schoolbox-api-docs/pull/163).