### PR TITLE
show actual / correct repeat_until date formats [SA-19233] (master)

### DIFF
--- a/openapi/components/responses/event-item.yaml
+++ b/openapi/components/responses/event-item.yaml
@@ -44,7 +44,7 @@ content:
           description: Blank for single event.
         repeat_until:
           type: string
-          example: "09\/03\/2025 8:00pm"
+          example: "09\/03\/2025"
           description: "Date event repeats until."
         type:
           type: integer

--- a/openapi/components/schemas/calendar/eventCommonProps.yaml
+++ b/openapi/components/schemas/calendar/eventCommonProps.yaml
@@ -37,7 +37,7 @@ properties:
     type: string
     format: date
     example: 2024-04-05
-    description: Date event repeats until, in RFC3339 format.
+    description: Date event repeats until, in either YYYY-MM-DD as well as DD/MM/YYYY formats.
   location:
     type: string
     example: Meeting room 1


### PR DESCRIPTION
we don't allow time in this field no `RFC3339` allowed:

Fixed to show what we actually allow:
![image](https://github.com/user-attachments/assets/08e0acbc-fe1e-4ee8-9fe0-04ea718f1bcd)
![image](https://github.com/user-attachments/assets/b1817b17-8345-4033-97be-f5bba93a47b0)
