### PR TITLE
Unify Calendar and Event sections [SA-19565] (master)

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -153,7 +153,6 @@ paths:
   /discussion/{contextType}/{contextId}/comments/{id}/comments:
     $ref: 'paths/discussion@{contextType}@{contextId}@comments@{id}@comments.yaml'
 
-
   /api/session:
     $ref: 'paths/api@session.yaml'
 
@@ -202,9 +201,6 @@ paths:
   /news/lists/folder/{id}:
     $ref: 'paths/news@lists@folder@{id}.yaml'
 
-  /calendar/event/attendance/{id}:
-    $ref: 'paths/calendar@event@attendance@{id}.yaml'
-
   /calendar/event/create:
     $ref: 'paths/calendar@event@create.yaml'
 
@@ -216,6 +212,9 @@ paths:
 
   /calendar/event/{id}/delete:
     $ref: 'paths/calendar@event@{id}@delete.yaml'
+
+  /calendar/event/attendance/{id}:
+    $ref: 'paths/calendar@event@attendance@{id}.yaml'
 
   /calendar/event/attendance/{id}/create:
     $ref: 'paths/calendar@event@attendance@{id}@create.yaml'

--- a/openapi/paths/calendar@event@attendance@{id}.yaml
+++ b/openapi/paths/calendar@event@attendance@{id}.yaml
@@ -1,6 +1,6 @@
 get:
   operationId: getCalendarEventAttendance
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Get an event's attendees
   description: |
     This will return a list of people that have been invited or RSVP to an an event.  It will include the status of their invitation and if they have accepted the invitation.

--- a/openapi/paths/calendar@event@attendance@{id}@accept.yaml
+++ b/openapi/paths/calendar@event@attendance@{id}@accept.yaml
@@ -1,6 +1,6 @@
 post:
   operationId: postCalendarEventAttendanceAccept
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Accept event invitation
   description: |
     This allows a user to accept an invitation.  Note that not all events will allow the user to accept an invitation.  They must either have been invited, or have the ability to invite themselves.

--- a/openapi/paths/calendar@event@attendance@{id}@create.yaml
+++ b/openapi/paths/calendar@event@attendance@{id}@create.yaml
@@ -1,6 +1,6 @@
 post:
   operationId: postCalendarEventAttendanceCreate
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Invite attendees to an event
   description: |
     Create invitations to the given event, for the given set of users.

--- a/openapi/paths/calendar@event@attendance@{id}@decline.yaml
+++ b/openapi/paths/calendar@event@attendance@{id}@decline.yaml
@@ -1,6 +1,6 @@
 post:
   operationId: postCalendarEventAttendanceDecline
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Decline event invitation
   description: |
     As the authenticated user, declines the invitation to attend the given

--- a/openapi/paths/calendar@event@attendance@{id}@delete.yaml
+++ b/openapi/paths/calendar@event@attendance@{id}@delete.yaml
@@ -1,6 +1,6 @@
 post:
   operationId: postCalendarEventAttendanceDelete
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Uninvite attendees from an event
   description: |
     Deletes invitations to the given event, for the given user.

--- a/openapi/paths/calendar@event@create.yaml
+++ b/openapi/paths/calendar@event@create.yaml
@@ -1,6 +1,6 @@
 post:
   operationId: calendarEvent.postCreate
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Create a calendar event
   description: |
     Creates a calendar event

--- a/openapi/paths/calendar@event@{id}@delete.yaml
+++ b/openapi/paths/calendar@event@{id}@delete.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../components/parameters/id.yaml
 post:
   operationId: calendarEvent.postDelete
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Delete a calendar event
   description: |
     Deletes a calendar event

--- a/openapi/paths/calendar@event@{id}@modify.yaml
+++ b/openapi/paths/calendar@event@{id}@modify.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../components/parameters/id.yaml
 post:
   operationId: calendarEvent.postModify
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Modify a calendar event
   description: |
     Modifies a calendar event

--- a/openapi/paths/calendar@event@{id}@move.yaml
+++ b/openapi/paths/calendar@event@{id}@move.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../components/parameters/id.yaml
 post:
   operationId: calendarEvent.postMove
-  tags: [calendar, event]
+  tags: [calendar]
   summary: Move a calendar event
   description: |
     Moves a calendar event


### PR DESCRIPTION
This removes the errant `Event` section.

![image](https://github.com/user-attachments/assets/e26854a5-5242-430b-ac71-7c529eceef6a)

These sections are grouped by the `tags` node, so having `tags: [calendar, event]` creates two sections - one called Calendar and another called Event - with the exact same contents in each. I'm not sure why someone would try to intentionally dupe those in this manner.

Anyway, I've combined them into the Calendar section. The maintenance of calendar events and the invitations to/attendances thereof, are (to me) still logically classified under Calendar.

If you wanted _event attendance_ specifically in its own section, you could still do that: but you have to make sure that only the attendance yamls use the `event` tag, not just proliferate it everywhere blindly.

```
calendar@event@attendance@{id}.yaml

get:
  operationId: getCalendarEventAttendance
  tags: [event]
```

![image](https://github.com/user-attachments/assets/378dc53d-1782-4739-a4bc-b0012dd5a7cc)

imho I think you'd want all your calendar event management stuff in one place, not separated like this at one end of the api docs and also at the other. How annoying is that