### PR TITLE
Deprecate normalisedMark in evidenceFeed & add gradientMark in replacement for 25.0 [SA-20057]

### DIFF
--- a/openapi/components/schemas/dueWorkFeedbackItem.yaml
+++ b/openapi/components/schemas/dueWorkFeedbackItem.yaml
@@ -15,6 +15,11 @@ properties:
     format: float
     example: 85
     description: The mark in numeric form
+  gradientMark:
+    type: string
+    nullable: true
+    description: The gradient colour equivalent of the mark. "none" if gradient marks are disabled.
+    example: '5'
   comment:
     type: string
     description: Comments about the work or the mark, by the user who assessed the work and gave the mark.

--- a/openapi/components/schemas/dueWorkFeedbackItem.yaml
+++ b/openapi/components/schemas/dueWorkFeedbackItem.yaml
@@ -11,6 +11,7 @@ properties:
     example: 'A'
   normalisedMark:
     type: number
+    deprecated: true
     format: float
     example: 85
     description: The mark in numeric form


### PR DESCRIPTION
With the new input/display mark types in 25.0:
- `normalisedMark` is now deprecated in the evidenceFeed API to prevent student's from viewing more granularity of grades than the display mark type would otherwise allow them to view
- `gradientMark` has been added to account for the one location we internally used the other field

![image](https://github.com/user-attachments/assets/2079f74f-758f-4baf-879f-96dbcddcef9a)

The normalised mark is still available under `GET /api/assessment/{id}`

**gradientMark** can be any of:
- `string`: If the grade gradient config is enabled and a mark exists (at the moment, this is from 0 to 10)
- `"none"`: If the grade gradient config is not enabled and a mark exists
- `null`: If no mark was given