### PR TITLE
Restore legacy date output in API docs [SA-21030]

### DIFF
--- a/openapi/components/responses/discussionComment-item.yaml
+++ b/openapi/components/responses/discussionComment-item.yaml
@@ -77,8 +77,12 @@ content:
         content:
           type: string
         createdAt:
-          $ref: ../schemas/dateTimeString.yaml
+          $ref: ../schemas/dateTimeLegacy.yaml
         updatedAt:
+          $ref: ../schemas/dateTimeLegacy.yaml
+        createdAtJson:
+          $ref: ../schemas/dateTimeString.yaml
+        updatedAtJson:
           $ref: ../schemas/dateTimeString.yaml
         _links:
           type: object

--- a/openapi/components/schemas/dateTimeLegacy.yaml
+++ b/openapi/components/schemas/dateTimeLegacy.yaml
@@ -1,0 +1,13 @@
+title: Datetime (Legacy)
+description: |
+  A JSON representation of a datetime.
+  For compatibility with existing code, can be defined as either:
+  * a RFC3339 string
+  * an object, which contains a datetime in several formats
+
+  Code using this representation should support both formats, with the knowledge
+  that the object representation is deprecated and will be removed eventually.
+deprecated: true
+oneOf:
+  - $ref: dateTimeString.yaml
+  - $ref: dateTimeLegacyObject.yaml

--- a/openapi/components/schemas/dateTimeLegacyObject.yaml
+++ b/openapi/components/schemas/dateTimeLegacyObject.yaml
@@ -28,3 +28,15 @@ properties:
     description: |
       The date as a RFC3339 string. Eg. "2018-01-28T00:00:00+11:00".
     example: "2018-01-28T00:00:00+11:00"
+  long:
+    type: string
+    description: |
+      A string representation of the date, localized to the Schoolbox instance's
+      settings.  Eg. "Sunday, 28 January 2018 12:00am".
+    example: "Sunday, 28 January 2018 12:00am"
+  relativeTime:
+    type: string
+    description: |
+      A human-friendly relative time representation of the date.
+      Eg. "2 years ago".
+    example: "2 years ago"

--- a/openapi/components/schemas/dateTimeLegacyObject.yaml
+++ b/openapi/components/schemas/dateTimeLegacyObject.yaml
@@ -1,0 +1,30 @@
+title: Datetime Object (Legacy)
+type: object
+readOnly: true
+deprecated: true
+required:
+  - json
+properties:
+  database:
+    type: string
+    description: |
+      A database representation of the date.  Eg. "2018-01-28 00:00:00"
+    example: "2018-01-28 00:00:00"
+  unixTimestamp:
+    type: integer
+    format: int64
+    description: |
+      The date as a Unix timestamp.  Eg. 1517058000
+    example: 1517058000
+  local:
+    type: string
+    description: |
+      A string representation of the date, localized to the Schoolbox
+      instance's settings.  Eg. "28/01/2018 12:00am".
+    example: "28/01/2018 12:00am"
+  json:
+    type: string
+    format: date-time
+    description: |
+      The date as a RFC3339 string. Eg. "2018-01-28T00:00:00+11:00".
+    example: "2018-01-28T00:00:00+11:00"

--- a/openapi/components/schemas/discussionComment-read.yaml
+++ b/openapi/components/schemas/discussionComment-read.yaml
@@ -11,9 +11,13 @@ properties:
   content:
     type: string
   createdAt:
-    $ref: ./dateTimeString.yaml
+    $ref: ../schemas/dateTimeLegacy.yaml
   updatedAt:
-    $ref: ./dateTimeString.yaml
+    $ref: ../schemas/dateTimeLegacy.yaml
+  createdAtJson:
+    $ref: ../schemas/dateTimeString.yaml
+  updatedAtJson:
+    $ref: ../schemas/dateTimeString.yaml
   parent:
     $ref: ./discussionComment-read.yaml
   children:

--- a/openapi/components/schemas/discussionComment-readList.yaml
+++ b/openapi/components/schemas/discussionComment-readList.yaml
@@ -72,8 +72,12 @@ properties:
         content:
           type: string
         createdAt:
-          $ref: ./dateTimeString.yaml
+          $ref: ../schemas/dateTimeLegacy.yaml
         updatedAt:
-          $ref: ./dateTimeString.yaml
+          $ref: ../schemas/dateTimeLegacy.yaml
+        createdAtJson:
+          $ref: ../schemas/dateTimeString.yaml
+        updatedAtJson:
+          $ref: ../schemas/dateTimeString.yaml
   metadata:
     $ref: ./listMetadata.yaml

--- a/openapi/components/schemas/discussionThread-read.yaml
+++ b/openapi/components/schemas/discussionThread-read.yaml
@@ -8,9 +8,13 @@ properties:
     type: boolean
     description: Is the thread open for further comments?
   createdAt:
-    $ref: ./dateTimeString.yaml
+    $ref: ../schemas/dateTimeLegacy.yaml
   updatedAt:
-    $ref: ./dateTimeString.yaml
+    $ref: ../schemas/dateTimeLegacy.yaml
+  createdAtJson:
+    $ref: ../schemas/dateTimeString.yaml
+  updatedAtJson:
+    $ref: ../schemas/dateTimeString.yaml
   _links:
     type: object
     properties:

--- a/openapi/paths/news@lists@feed.yaml
+++ b/openapi/paths/news@lists@feed.yaml
@@ -46,6 +46,13 @@ get:
                             The datetime the news article was originally read by the user.
 
                             May be null, in which case the user has not read the article
+                        - $ref: ../components/schemas/dateTimeLegacy.yaml
+                    viewedAtJson:
+                      allOf:
+                        - description: |
+                            The datetime the news article was originally read by the user.
+
+                            May be null, in which case the user has not read the article
                         - $ref: ../components/schemas/dateTimeString.yaml
                     _links:
                       $ref: ../components/schemas/news/links.yaml


### PR DESCRIPTION
The legacy formats should be documented, whilst they still exist.