### PR TITLE
Pastoral: Update docs [SA-21481] (master)

### DIFF
--- a/openapi/components/requestBodies/pastoral-partial-item.yaml
+++ b/openapi/components/requestBodies/pastoral-partial-item.yaml
@@ -70,7 +70,7 @@ content:
           type: string
           nullable: true
         points:
-          description: Points of this pastoral record.
+          description: Points of this pastoral record. Setting this to null will remove the points value from the pastoral record.
           type: number
           format: float
           minimum: -100000


### PR DESCRIPTION
This updates API docs to explain what `null` does.

<img width="1469" height="1321" alt="image" src="https://github.com/user-attachments/assets/6e8db774-8360-4022-a817-c6a30c05ddff" />
