### PR TITLE
Dialog Agent: Add dialogAgent to enums [SA-21399] (master)

### DIFF
--- a/openapi/components/schemas/assessment-item.yaml
+++ b/openapi/components/schemas/assessment-item.yaml
@@ -17,6 +17,7 @@ properties:
       - project
       - LTI
       - lessonPlan
+      - dialogAgent
     example: task
   folder:
     description: |

--- a/openapi/paths/assessment.yaml
+++ b/openapi/paths/assessment.yaml
@@ -65,6 +65,7 @@ parameters:
             - dueWork
             - LTI
             - project
+            - dialogAgent
           example: dueWork
         folder:
           oneOf:


### PR DESCRIPTION
Adds `dialogAgent` to the enums. I haven't really seen any other place(s) that need updating - there wasn't mention of anything beyond this tiny area.

<img width="1850" height="1173" alt="image" src="https://github.com/user-attachments/assets/4eacf190-8a7a-46dc-ba6d-bcbc2c439afa" />

<img width="1850" height="1173" alt="image" src="https://github.com/user-attachments/assets/0f590807-c3a3-4259-acf9-7cd25b1d8b33" />
