### PR TITLE
Groups: Add roletype to api [SA-21686] (master)

### DIFF
--- a/openapi/components/responses/group/group-user-list.yaml
+++ b/openapi/components/responses/group/group-user-list.yaml
@@ -122,6 +122,18 @@ content:
                 description: The name of the Role, may not be unique.
                 example: Staff
 
+              roleType:
+                type: string
+                nullable: false
+                description: |
+                  The type of this role. Different role types have different levels of
+                  access to different parts of Schoolbox.
+                enum:
+                  - staff
+                  - student
+                  - parent
+                  - guest
+
               isStaff:
                 type: boolean
                 example: true


### PR DESCRIPTION
Adds `roleType` to the `getData` endpoint: http://127.0.0.1:8000/?debug#get-/group/getData/-id-

<img width="1467" height="2546" alt="image" src="https://github.com/user-attachments/assets/8bd0b01f-9ba4-4c7e-92ff-39245f31ee85" />
