### PR TITLE
Document GET /groups/search endpoint [SA-22075]

### DIFF
--- a/openapi/components/responses/group/group-search-list.yaml
+++ b/openapi/components/responses/group/group-search-list.yaml
@@ -1,0 +1,47 @@
+description: A paginated list of groups
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: The group's unique identifier.
+                example: 123
+              name:
+                type: string
+                description: The group's name.
+                example: First XI Basketball
+              codes:
+                type: array
+                description: All codes associated with the group. May be empty.
+                items:
+                  type: string
+                example: [BASK-01]
+              type:
+                type: string
+                enum: [private, moderated, free]
+                description: The group's join type.
+                example: moderated
+              url:
+                type: string
+                description: Relative URL to the group's homepage.
+                example: /groups/123
+              memberCount:
+                type: integer
+                description: |
+                  Number of active members. Excludes pending and denied users.
+                example: 15
+        next:
+          type: string
+          nullable: true
+          description: |
+            Opaque cursor for the next page of results.
+            Pass this value as the `cursor` parameter on the next request.
+            `null` when there are no further results.
+          example: eyJpZCI6MTIzfQ==

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -73,6 +73,11 @@ tags:
     description: |
       Upload files.
 
+  - name: group
+    x-displayName: Groups
+    description: |
+      Search and manage groups.
+
   - name: Learning Moment
     x-displayName: Learning Moment
     description: |
@@ -318,6 +323,9 @@ paths:
 
   /api/config/{configName}:
     $ref: 'paths/api@config@{configName}.yaml'
+
+  /groups/search:
+    $ref: 'paths/groups@search.yaml'
 
   /group/getData/{id}:
     $ref: 'paths/group@getData@{id}.yaml'

--- a/openapi/paths/groups@search.yaml
+++ b/openapi/paths/groups@search.yaml
@@ -1,0 +1,31 @@
+get:
+  operationId: groupSearch
+  tags: [group]
+  summary: Search for groups
+  description: |
+    Returns a paginated, searchable list of all groups in the system.
+
+    This endpoint is only available to superusers.
+  parameters:
+    - name: q
+      in: query
+      description: |
+        Partial name match. Returns groups whose name contains the given string.
+      schema:
+        type: string
+    - name: type
+      in: query
+      description: |
+        Filter by group join type.
+      schema:
+        type: string
+        enum: [private, moderated, free]
+    - $ref: ../components/parameters/limit.yaml
+    - $ref: ../components/parameters/cursor.yaml
+  responses:
+    '200':
+      $ref: ../components/responses/group/group-search-list.yaml
+    '400':
+      $ref: ../components/responses/problem.yaml
+    default:
+      $ref: ../components/responses/problem.yaml


### PR DESCRIPTION
## Summary

- Adds `GET /groups/search` to the API docs under a new **Groups** section
- Documents query parameters: `q` (name filter), `type` (private/moderated/free), `limit`, and `cursor`
- Documents the paginated response shape: `results` array with group fields and `next` cursor

## Related

Schoolbox implementation PR: alaress/schoolbox#34760

## Test Plan

- [ ] Verify spec passes Redocly lint (`npm test`)
- [ ] Confirm the Groups section appears in the rendered docs
- [ ] Confirm `cursor` and `limit` parameters render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)